### PR TITLE
Add D3 zoom example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # rtest
+
+This repository contains test examples. See [d3-zoom-graph.html](d3-zoom-graph.html) for a D3.js visualization that reveals node labels when zoom level exceeds a constant threshold. The nodes and labels scale with the zoom transform so they maintain their relative positions on the canvas.

--- a/d3-zoom-graph.html
+++ b/d3-zoom-graph.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>D3 Zoom Graph</title>
+  <script src="https://d3js.org/d3.v7.min.js"></script>
+  <style>
+    .node circle {
+      fill: steelblue;
+    }
+    .label {
+      font: 10px sans-serif;
+    }
+  </style>
+</head>
+<body>
+  <svg id="graph" width="600" height="400"></svg>
+  <script>
+    const SHOW_LABEL_ZOOM = 2; // constant to show labels
+    const BASE_RADIUS = 10;
+    const BASE_FONT_SIZE = 10;
+    const width = 600;
+    const height = 400;
+
+    const nodes = [
+      { id: 1, name: 'Node 1' },
+      { id: 2, name: 'Node 2' },
+      { id: 3, name: 'Node 3' },
+      { id: 4, name: 'Node 4' }
+    ];
+
+    const links = [
+      { source: 1, target: 2 },
+      { source: 2, target: 3 },
+      { source: 3, target: 4 },
+      { source: 4, target: 1 }
+    ];
+
+    const svg = d3.select('#graph');
+    const g = svg.append('g');
+
+    const simulation = d3.forceSimulation(nodes)
+      .force('link', d3.forceLink(links).id(d => d.id).distance(80))
+      .force('charge', d3.forceManyBody().strength(-200))
+      .force('center', d3.forceCenter(width / 2, height / 2));
+
+    const link = g.selectAll('.link')
+      .data(links)
+      .enter().append('line')
+      .attr('stroke', '#999');
+
+    const node = g.selectAll('.node')
+      .data(nodes)
+      .enter().append('g')
+      .attr('class', 'node');
+
+    const circle = node.append('circle')
+      .attr('r', BASE_RADIUS);
+
+    const label = node.append('text')
+      .attr('class', 'label')
+      .attr('x', 12)
+      .attr('dy', '.35em')
+      .text(d => d.name)
+      .style('display', 'none'); // hide initially
+
+    simulation.on('tick', () => {
+      link
+        .attr('x1', d => d.source.x)
+        .attr('y1', d => d.source.y)
+        .attr('x2', d => d.target.x)
+        .attr('y2', d => d.target.y);
+
+      node
+        .attr('transform', d => `translate(${d.x},${d.y})`);
+    });
+
+    const zoom = d3.zoom()
+      .scaleExtent([0.5, 5])
+      .on('zoom', (event) => {
+        g.attr('transform', event.transform);
+        circle.attr('r', BASE_RADIUS * event.transform.k);
+        label.style('font-size', `${BASE_FONT_SIZE * event.transform.k}px`);
+        label.style("display", event.transform.k >= SHOW_LABEL_ZOOM ? "block" : "none");
+      });
+
+    svg.call(zoom);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a small D3.js example showing a graph
- update README with a reference to the example
- scale node radius and label font-size on zoom

## Testing
- `git log -1 --stat`
